### PR TITLE
Support transparent server restart after upgrading

### DIFF
--- a/build-nextcloud-app.sh
+++ b/build-nextcloud-app.sh
@@ -44,6 +44,11 @@ test -d "${app_name}/collabora" || mkdir -p "${app_name}/collabora"
 test -f "${app_name}/collabora/Collabora_Online.AppImage" || curl "$APPIMAGE_URL" -o "${app_name}/collabora/Collabora_Online.AppImage"
 chmod a+x "${app_name}/collabora/Collabora_Online.AppImage"
 
+# Get the version hash from loolwsd and set it in proxy.php
+HASH=`./${app_name}/collabora/Collabora_Online.AppImage --version-hash`
+echo "HASH: $HASH"
+sed -i "s/%LOOLWSD_VERSION_HASH%/$HASH/g" ${app_name}/proxy.php
+
 echo "Signing…"
 $occ integrity:sign-app --privateKey=${cert_dir}/${app_name}.key --certificate=${cert_dir}/${app_name}.crt --path=$(pwd)/${app_name}
 tar czf ${app_name}.tar.gz ${app_name}


### PR DESCRIPTION
The build script now bakes the server version hash
number in proxy.php that it is built against,
such that the latter can use it to detect stale servers.

After an upgrade, proxy.php will be running the newer
version but, unless loolwsd is restarted, the server
version returned in hosting/capabilities will be
unexpected (i.e. will not match the one in proxy.php).
When a mismatch is detected, proxy.php will kill
the loolwsd process and start a new instance.

Also replaced a number of tabs with spaces and fixed
indentation issues to help readability and consistency.