### PR TITLE
Use HTTP_HOST instead of SERVER_NAME because it contains the port

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -242,7 +242,7 @@ if (!$local) {
 // Fetch our headers for later
 $headers = apache_request_headers();
 
-$proxyURL .= $_SERVER['SERVER_NAME'] . $_SERVER['SCRIPT_NAME'] . '?req=';
+$proxyURL .= $_SERVER['HTTP_HOST'] . $_SERVER['SCRIPT_NAME'] . '?req=';
 debug_log("ProxyPrefix: '$proxyURL'");
 
 $realRequest = $_SERVER['REQUEST_METHOD'] . " " . $request . " " . $_SERVER['SERVER_PROTOCOL'];


### PR DESCRIPTION
The app seemed to have issues with Nextcloud running on a port that
was not 80/443.