### PR TITLE
polyfill apache_request_headers for PHP <= 7.2

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -140,6 +140,25 @@ function startsWith($string, $with) {
     return (substr($string, 0, strlen($with)) === $with);
 }
 
+if (!function_exists('getallheaders'))
+{
+	// polyfill, e.g. on PHP 7.2 setups with nginx.
+	// Can be removed when 7.2 becomes unsupported
+	function getallheaders()
+	{
+		$headers = [];
+		if (!is_array($_SERVER)) {
+			return $headers;
+		}
+		foreach ($_SERVER as $name => $value) {
+			if (substr($name, 0, 5) == 'HTTP_') {
+				$headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+			}
+		}
+		return $headers;
+	}
+}
+
 // avoid unwanted escaping of req= parameter
 $request = $_SERVER['QUERY_STRING'];
 // only asking for status?
@@ -240,7 +259,7 @@ if (!$local) {
 }
 
 // Fetch our headers for later
-$headers = apache_request_headers();
+$headers = getallheaders();
 
 $proxyURL .= $_SERVER['HTTP_HOST'] . $_SERVER['SCRIPT_NAME'] . '?req=';
 debug_log("ProxyPrefix: '$proxyURL'");


### PR DESCRIPTION
On some setups (PHP 7.2 with nginx) apache_request_headers() is not available, so query.php is causing server errors. getallheaders is an alias to apache_request_headers, and going for the apache-free naming is more sensible imho, as it not only covers apache.

Beware, some headers might not get the proper casing. I have not seen issues on quick testing though. This is based on a prior comment to https://www.php.net/manual/en/function.getallheaders.php. 