### PR TITLE
Check for fontconfig in proxy.php?status.

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -110,6 +110,10 @@ function checkLoolwsdSetup()
     else if (php_uname('m') !== 'x86_64')
         return 'not_x86_64';
 
+    exec('/sbin/ldconfig -p | grep fontconfig > /dev/null 2>&1', $output, $return);
+    if ($return)
+        return 'no_fontconfig';
+
     return '';
 }
 


### PR DESCRIPTION
fontconfig is necessary for the AppImage to work, but many server
systems do not have it.

I've considered adding it to the AppImage, but then there are many
reports of AppImages not working due to containing fontconfig older than
the system one in case the newer fontconfig contains changes in the
configuration files (like new xml tags) that are not known for the older
one.