### PR TITLE
Improvements in the AppImage startup

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -66,14 +66,11 @@ function startLoolwsd()
     global $appImage;
     @chmod($appImage, 0744);
 
-    $launchCmd = $appImage;
-
-    // FUSE usually does not work in a docker, unpack instead
-    if (preg_match('/(docker|lxc)/', file_get_contents('/proc/1/cgroup')))
-        $launchCmd .= ' --appimage-extract-and-run';
+    // Extract the AppImage if FUSE is not available
+    $launchCmd = "( $appImage || $appImage --appimage-extract-and-run ) >/dev/null & disown";
 
     debug_log("Launch the loolwsd server: $launchCmd");
-    exec("$launchCmd >/dev/null & disown", $output, $return);
+    exec($launchCmd, $output, $return);
     if ($return)
     {
         debug_log("Failed to launch server at $appImage.");

--- a/proxy.php
+++ b/proxy.php
@@ -190,8 +190,10 @@ if ($statusOnly) {
         $err = checkLoolwsdSetup();
         if (!empty($err))
             print '{"status":"error","error":"' . $err . '"}';
-        else
-            print '{"status":"stopped"}';
+        else {
+            startLoolwsd();
+            print '{"status":"starting"}';
+        }
     } else if ($errno == 111) {
         print '{"status":"starting"}';
     } else {


### PR DESCRIPTION
Most notably this removes the attempt to detect Docker / LXC, and instead just falls back to --appimage-extract-and-run when the run without that fails. That should cover even the cases when the FUSE is not installed on the system (that would otherwise run with that just fine).