### PR TITLE
Detect non-glibc systems.

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -111,6 +111,10 @@ function checkLoolwsdSetup()
     if ($return)
         return 'no_fontconfig';
 
+    exec("ldd $appImage", $output, $return);
+    if ($return)
+        return 'no_glibc';
+
     return '';
 }
 


### PR DESCRIPTION
The AppImage is known to fail on musl-based systems, see

  https://github.com/AppImage/AppImageKit/issues/1015