### PR TITLE
Better check for the fail on musl-based distros.

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -107,9 +107,9 @@ function checkLoolwsdSetup()
     else if (!is_callable('exec'))
         return 'exec_disabled';
 
-    exec("ldd $appImage", $output, $return);
+    exec("$appImage --appimage-version", $output, $return);
     if ($return)
-        return 'no_glibc';
+        return 'appimage_not_executable';
 
     exec('( /sbin/ldconfig -p || scanelf -l ) | grep fontconfig > /dev/null 2>&1', $output, $return);
     if ($return)


### PR DESCRIPTION
This is the ultimate check; but unfortunately we cannot be 100% sure it
is due to the glibc vs. musl, so report only the general error.