### PR TITLE
Another try for the right check how to detect musl-based distros.

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -107,9 +107,9 @@ function checkLoolwsdSetup()
     else if (!is_callable('exec'))
         return 'exec_disabled';
 
-    exec("$appImage --appimage-version", $output, $return);
+    exec("LD_TRACE_LOADED_OBJECTS=1 $appImage", $output, $return);
     if ($return)
-        return 'appimage_not_executable';
+        return 'no_glibc';
 
     exec('( /sbin/ldconfig -p || scanelf -l ) | grep fontconfig > /dev/null 2>&1', $output, $return);
     if ($return)


### PR DESCRIPTION
Let me summarize the problems:

* ldd - on some distros, it reported "not a dynamic executable" and
  returned an error (even though the AppImage would work there)

* executing the AppImage with --appimage-version - from a reason that
  escapes me this tries to fuse mount the AppImage; so on distros where
  we fallback to --appimage-extract-and-run, this fails

So the hope is that that this will finally solve the problem - on the
"working" distros it seems to provide the info even on the distros where
ldd does not work; and on the non-working ones this returns a failure.