### PR TITLE
Disable http scheme detection in proxy

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -236,12 +236,8 @@ if ($statusOnly) {
     http_response_code(200);
     exit();
 }
-// URL into this server of the proxy script.
-if (isset($_SERVER['HTTPS'])) {
-    $proxyURL = "https://";
-} else {
-    $proxyURL = "http://";
-}
+
+$proxyURL = "//";
 
 // Start the appimage if necessary
 if (!$local)


### PR DESCRIPTION
Try to fix #2 

This delegate scheme detection to the browser, tested on my NC19 installation under https reverse proxy.

I can't manage to test it completly since i'm running a docker setup and AppImage launch seems to be broken (cf https://github.com/CollaboraOnline/richdocumentscode/issues/26) so I'm stuck on the next step ... It could be nice if someone could test it under a "classic" setup.