### PR TITLE
detect HTTPS from proxies

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -237,7 +237,10 @@ if ($statusOnly) {
     exit();
 }
 // URL into this server of the proxy script.
-if (isset($_SERVER['HTTPS'])) {
+if ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+	|| (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https' )
+	|| (isset($_SERVER['HTTP_X_FORWARDED_SSL']) && $_SERVER['HTTP_X_FORWARDED_SSL'] === 'on')
+) {
     $proxyURL = "https://";
 } else {
     $proxyURL = "http://";


### PR DESCRIPTION
fixes #2 

@juliushaertl stated in the issue:

> I'm not entirely sure how to solve this properly. In Nextcloud we use HTTP_X_FORWARDED_PROTO and HTTP_X_FORWARDED_FOR but we also have dedicated config.php flags to override the protocol/host, but that would require you to somehow setup the server classes to access the config values, so that would have a performance impact again.

Now, I understand richdocumentscode is agnostic to whatever service runs on top, Nextcloud or not. So adding Nextcloud logic is not needed or reasonable, but expending it is. 

What is not included is also whether the forwarding proxy is trusted, or not. Upgrading to HTTPS should not do any harm, though, and downgrading is prevented, as it does not overrule the HTTPS env.

P.S.: for completeness, it only has effect when a discovery.xml is not already cached in Nextcloud (${DATADIR}/appdata_${INSTANCEID}/richdocuments/richdocuments/discovery.xml) – that file can be removed and will be recreated with the new data on demand.