### PR TITLE
Add architecture dependency

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -30,6 +30,7 @@ This app provides a built-in server with all of the document editing features of
     <screenshot>https://www.collaboraoffice.com/nextcloud/code/collabora-online-screenshot-5.png</screenshot>
     <dependencies>
         <nextcloud min-version="19" max-version="20"/>
+        <architecture>x86_64</architecture>
     </dependencies>
     <settings>
         <admin>OCA\RichDocumentsCODE\Settings\Admin</admin>


### PR DESCRIPTION
@timar Not sure how you build the arm app but that should then just replace the architecture entry with aarch64

This will make sure that the app cannot be installed by accident on the wrong architecture and the user will be seeing a warning in the Nextcloud app management about it with Nextcloud 20+ (https://github.com/nextcloud/server/pull/22844)

