### PR TITLE
If appimage is starting send cached capabilities

### DIFF
--- a/build-nextcloud-app.sh
+++ b/build-nextcloud-app.sh
@@ -49,6 +49,11 @@ HASH=`./${app_name}/collabora/Collabora_Online.AppImage --version-hash`
 echo "HASH: $HASH"
 sed "s/%LOOLWSD_VERSION_HASH%/$HASH/g" ../proxy.php > ${app_name}/proxy.php
 
+# Fetch capabilities from AppImage for cache
+PID_FILE="/tmp/loolwsd.pid"
+`./${app_name}/collabora/Collabora_Online.AppImage 2>/dev/null` & (sleep 3 && curl "http://localhost:9983/hosting/capabilities" --max-time 10 -o "${app_name}/capabilities.json") || (echo && echo "ERROR: Cannot fetch capabilities!" && echo)
+kill -9 `cat $PID_FILE` 2>/dev/null || (echo && echo "Failed to run Collabora Online Appimage" && echo)
+
 # check if we are building for arm64
 if [[ "$APPIMAGE_URL" =~ "arm64" ]]; then
     echo "Building for arm64"

--- a/build-nextcloud-app.sh
+++ b/build-nextcloud-app.sh
@@ -49,11 +49,6 @@ HASH=`./${app_name}/collabora/Collabora_Online.AppImage --version-hash`
 echo "HASH: $HASH"
 sed "s/%LOOLWSD_VERSION_HASH%/$HASH/g" ../proxy.php > ${app_name}/proxy.php
 
-# Fetch capabilities from AppImage for cache
-PID_FILE="/tmp/loolwsd.pid"
-`./${app_name}/collabora/Collabora_Online.AppImage 2>/dev/null` & (sleep 3 && curl "http://localhost:9983/hosting/capabilities" --max-time 10 -o "${app_name}/capabilities.json") || (echo && echo "ERROR: Cannot fetch capabilities!" && echo)
-kill -9 `cat $PID_FILE` 2>/dev/null || (echo && echo "Failed to run Collabora Online Appimage" && echo)
-
 # check if we are building for arm64
 if [[ "$APPIMAGE_URL" =~ "arm64" ]]; then
     echo "Building for arm64"

--- a/proxy.php
+++ b/proxy.php
@@ -206,15 +206,20 @@ debug_log("get URI " . $request);
 if ($request == '' && !$statusOnly)
     errorExit("Missing, required req= parameter");
 
-if (startsWith($request, '/hosting/capabilities') && !isLoolwsdRunning() && file_exists('capabilities.json')) {
+if (startsWith($request, '/hosting/capabilities') && !isLoolwsdRunning()) {
     header('Content-type: application/json');
     header('Cache-Control: no-store');
-    $capabilities = file_get_contents('capabilities.json');
-    if ($capabilities !== false) {
-        print $capabilities;
-        http_response_code(200);
-        exit();
-    }
+
+    print '{
+        "convert-to":{"available":true},
+        "hasMobileSupport":true,
+        "hasProxyPrefix":false,
+        "hasTemplateSaveAs":false,
+        "hasTemplateSource":true
+    }';
+
+    http_response_code(200);
+    exit();
 }
 
 // If we can't get a socket open in 3 seconds when that is backed by

--- a/proxy.php
+++ b/proxy.php
@@ -206,6 +206,17 @@ debug_log("get URI " . $request);
 if ($request == '' && !$statusOnly)
     errorExit("Missing, required req= parameter");
 
+if (startsWith($request, '/hosting/capabilities') && !isLoolwsdRunning() && file_exists('capabilities.json')) {
+    header('Content-type: application/json');
+    header('Cache-Control: no-store');
+    $capabilities = file_get_contents('capabilities.json');
+    if ($capabilities !== false) {
+        print $capabilities;
+        http_response_code(200);
+        exit();
+    }
+}
+
 // If we can't get a socket open in 3 seconds when that is backed by
 // a dedicated thread, then we have a server missing in action.
 $local = @fsockopen("localhost", 9983, $errno, $errstr, 3);


### PR DESCRIPTION
Build script runs AppImage and saves capabilities endpoint
output to file.
When AppImage is not started yet - cached file content will be sent.
Otherwise proxy will redirrect to the acctual endpoint.