### PR TITLE
Security issue : modification proposed to avoid /proc in openbasedir

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -59,7 +59,8 @@ function getLoolwsdPid()
 
 function isLoolwsdRunning()
 {
-    return file_exists('/proc/' . getLoolwsdPid());
+    //return file_exists('/proc/' . getLoolwsdPid());
+    return posix_kill(getLoolwsdPid(),0);
 }
 
 function startLoolwsd()
@@ -100,8 +101,9 @@ function startLoolwsd()
 
 function stopLoolwsd()
 {
-    $pid = getLoolwsdPid();
-    if (file_exists('/proc/$pid'))
+    //$pid = getLoolwsdPid();
+    //if (file_exists('/proc/$pid'))
+    if (posix_kill(getLoolwsdPid(),0))    
     {
         debug_log("Stopping the loolwsd server with pid: $pid");
         exec("kill -s TERM $pid");


### PR DESCRIPTION
I propose to remove reference to /proc directory.
/proc make mandatory to openbasedir /proc, what is quite dangerous.

Refer to https://stackoverflow.com/questions/9874331/how-to-check-whether-specified-pid-is-currently-running-without-invoking-ps-from
and php -d memory_limit=512M occ app:install richdocumentscode creating openbase_dir error #107