### PR TITLE
Check if exec is available before calling

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -140,7 +140,8 @@ function checkCoolwsdSetup()
     if (!is_executable($appImage))
         return 'appimage_not_executable';
 
-    if (@exec('echo EXEC') !== "EXEC")
+    $disabledFunctions = explode(',', ini_get('disable_functions'));
+    if (!in_array('exec', $disabledFunctions) || @exec('echo EXEC') !== "EXEC")
         return 'exec_disabled';
 
     exec("LD_TRACE_LOADED_OBJECTS=1 $appImage", $output, $return);


### PR DESCRIPTION
This should make sure that we return a proper error instead of throwing a fatal one to the nextcloud log

Closes https://github.com/nextcloud/richdocuments/issues/2345