### PR TITLE
docs(README): Update disk space reqs + minor misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ If the app is built with an ARM64 AppImage, it will be named as richdocumentscod
 - 2 CPU cores
 - 1 GB RAM + 100 MB RAM / user
 - 100 kbit/s network bandwidth / user
-- 350 MB space on disk
-- Nextcloud 19 with [Collabora Online app](https://apps.nextcloud.com/apps/richdocuments) 3.7.0 or higher
-- glibc ([AppImage does not support musl libc](https://github.com/AppImage/AppImageKit/issues/1015))
+- 300 MB space on disk (800 MB in `/tmp` if not using FUSE)
+- Nextcloud 19 with the [Nextcloud Office app](https://apps.nextcloud.com/apps/richdocuments) 3.7.0 or higher
+- A glibc based distribution/container ([AppImage does not support musl libc](https://github.com/AppImage/AppImageKit/issues/1015))
 - Fontconfig (libfontconfig.so.1 - required by Collabora_Online.AppImage)
 ### Optional
 - Kernel supporting the FUSE (Filesystem in Userspace)
 - FUSE 2 (libfuse.so.2)
 
-**Note:** If FUSE support is not present, the AppImage will be started with `--appimage-extract-and-run` parameter.
+**Note:** If FUSE support is not present, a warning (`dlopen(): error loading libfuse.so.2`) will be generated, but then the AppImage will be started with the `--appimage-extract-and-run` parameter automatically as a fallback.
 
 ## Usage and installation
 


### PR DESCRIPTION
- Add disk space required when FUSE isn't available since it's significant
- Adapt updated name for Nextcloud Office integration app (https://github.com/nextcloud/richdocuments/pull/1921)
- Reword glibc requirement slightly for clarity
- Extend paragraph for `--appimage-extract-and-run` fallback behavior by clarifying the warnings related to FUSE are expected in that scenario