### PR TITLE
Move calls to http_response_code() before doing print()

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -26,12 +26,12 @@ function debug_log($msg)
 
 function errorExit($msg)
 {
+    http_response_code(400);
     print "<html><body>\n";
     print "<h1>Socket proxy error</h1>\n";
     print "<p>Error: " . htmlspecialchars($msg) . "</p>\n";
     print "</body></html>\n";
     error_log("richdocumentscode (proxy.php) error exit, PID: " . getmypid() . ", Message: $msg");
-    http_response_code(400);
     exit();
 }
 
@@ -242,7 +242,6 @@ if (startsWith($request, '/hosting/capabilities') && !isCoolwsdRunning()) {
         "hasTemplateSource":true
     }';
 
-    http_response_code(200);
     exit();
 }
 
@@ -293,7 +292,6 @@ if ($statusOnly) {
         fclose($local);
     }
 
-    http_response_code(200);
     exit();
 }
 // URL into this server of the proxy script.


### PR DESCRIPTION
Calling http_response_code() after print() has no effect and it logs a warning "headers already sent" on the web server logs. When PHP has display_errors enabled, the warning is also sent as a response to the browser, and the browser is unable to open CODE application.
This commit fixes #286 and #270 by moving one http_response_code(400) call before "print", and by removing two useless http_response_code(200);, which is the default value.
