### PR TITLE
Clean up `proxy.php` by extracting request, status, and streaming helpers

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -18,6 +18,10 @@
 // test with:
 // http://localhost/richproxy/proxy.php?req=/browser/dist/cool.html?file_path=file:///opt/libreoffice/online/test/data/hello-world.odt
 
+// ------------------------------------------------------------
+// Helper functions
+// ------------------------------------------------------------
+
 function debug_log($msg)
 {
     // Disabled for production; enable for debugging
@@ -203,6 +207,27 @@ function isMultipartRequest($headers)
     return strpos(strtolower($contentType), 'multipart/form-data') !== false;
 }
 
+function parseProxyMode(string $queryString): array
+{
+    if (startsWith($queryString, 'status')) {
+        return ['statusOnly' => true, 'request' => ''];
+    }
+
+    if (startsWith($queryString, 'req=')) {
+        $request = substr($queryString, strlen('req='));
+        if (substr($request, 0, 1) !== '/') {
+            errorExit("First ?req= param should be an absolute path: '" . $request . "'");
+        }
+        return ['statusOnly' => false, 'request' => $request];
+    }
+
+    errorExit("The param should be 'status' or 'req=...', but is: '" . $queryString . "'");
+}
+
+// ------------------------------------------------------------
+// Main script flow
+// ------------------------------------------------------------
+
 debug_log('Proxy v1');
 
 // Let the webserver time us out in its own good time.
@@ -217,20 +242,7 @@ $pidfile = "$tmp_dir/coolwsd.pid";
 
 // avoid unwanted escaping of req= parameter
 $request = $_SERVER['QUERY_STRING'];
-// only asking for status?
-$statusOnly = false;
-
-// handle parameters
-if (startsWith($request, 'status')) {
-    $request = '';
-    $statusOnly = true;
-} else if (startsWith($request, 'req=')) {
-    $request = substr($request, strlen('req='));
-    if (substr($request, 0, 1) !== '/')
-        errorExit("First ?req= param should be an absolute path: '" . $request . "'");
-} else {
-    errorExit("The param should be 'status' or 'req=...', but is: '" . $request . "'");
-}
+[$statusOnly, $request] = parseProxyMode($request);
 
 debug_log("get URI " . $request);
 

--- a/proxy.php
+++ b/proxy.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-// test with:
+// Example local test URL:
 // http://localhost/richproxy/proxy.php?req=/browser/dist/cool.html?file_path=file:///opt/libreoffice/online/test/data/hello-world.odt
 
 // ------------------------------------------------------------
@@ -78,7 +78,7 @@ function startCoolwsd()
         $remoteFontConfig = "--o:remote_font_config.url=" . $remoteFontConfigUrl;
     }
 
-    // Check if IPv6 has been disabled
+    // Check whether IPv6 has been disabled.
     $IPv4only = "";
     $launchCmd = "ip -6 addr";
     debug_log("Testing disabled IPv6: $launchCmd");
@@ -89,23 +89,23 @@ function startCoolwsd()
         $IPv4only = "--o:net.proto=IPv4";
     }
 
-    // Extract the AppImage if FUSE is not available
-    // net.lok_allow.host[14] is the next empty slot after the last element of the default list
-    // when lok_allow does not contain the Nextcloud host, it is not possible to insert image from Nextcloud
-    // we have to set explicitly, because storage.wopi.alias_groups[@mode] is 'first' in case of richdocumentscode
+    // Launch the AppImage normally, with a fallback for environments without FUSE.
+    // net.lok_allow.host[14] is the next empty slot after the last element of the default list.
+    // If lok_allow does not contain the Nextcloud host, it is not possible to insert images from Nextcloud.
+    // We have to set it explicitly because storage.wopi.alias_groups[@mode] is 'first' in case of richdocumentscode.
     $lok_allow = "--o:net.lok_allow.host[14]=" . escapeshellarg($_SERVER['HTTP_HOST']);
     $launchCmd = "bash -c \"( $appImage $remoteFontConfig $IPv4only $lok_allow --pidfile=$pidfile || $appImage --appimage-extract-and-run $remoteFontConfig $IPv4only $lok_allow --pidfile=$pidfile) >/dev/null & disown\"";
 
-    // Remove stale lock file (just in case)
+    // Remove a stale lock file if one exists.
     if (file_exists("$lockfile"))
         if (time() - filectime("$lockfile") > 60 * 5)
             unlink("$lockfile");
 
-    // Prevent second start
+    // Prevent a second concurrent start.
     $lock = @fopen("$lockfile", "x");
     if ($lock)
     {
-        // We start a new server, we don't need stale pidfile around
+        // We are starting a new server, so we do not need a stale pidfile.
         if (file_exists("$pidfile"))
             unlink("$pidfile");
 
@@ -134,8 +134,8 @@ function stopCoolwsd()
     }
 }
 
-// Check that the setup is suitable for running the coolwsd.
-// Returns the error ID if we find a problem.
+// Check whether the environment is suitable for running coolwsd.
+// Returns an error ID if a problem is found.
 function checkCoolwsdSetup()
 {
     global $appImage;
@@ -174,7 +174,7 @@ function startsWith($string, $with) {
     return (substr($string, 0, strlen($with)) === $with);
 }
 
-// parse and emit headers using 'header' ...
+// Parse upstream response headers and forward them with header().
 function parseLastHeader(&$chunk, &$contentLength)
 {
     $headers = explode("\r\n", $chunk);
@@ -196,7 +196,7 @@ function parseLastHeader(&$chunk, &$contentLength)
         }
         header($h);
     }
-    // keep looking for the next header.
+    // Keep looking for the next header fragment.
     $chunk = substr($chunk, $chop);
     return $endOfHeaders;
 }
@@ -229,8 +229,8 @@ function getProxyScheme(): string
     if ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
         || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https')
         || (isset($_SERVER['HTTP_X_FORWARDED_SSL']) && $_SERVER['HTTP_X_FORWARDED_SSL'] === 'on')
-	   ) {
-    	return 'https://';
+    ) {
+        return 'https://';
     }
 
     return 'http://';
@@ -265,23 +265,23 @@ function handleStatusRequest($local, $errno): void
     );
 
     if ($response) {
-		// Version check.
+        // Version check.
         $obj = json_decode($response);
         $expVer = '%COOLWSD_VERSION_HASH%';
         $actVer = substr($obj->{'productVersionHash'}, 0, strlen($expVer));
 
-		// deliberately split so that sed does not touch this during build-time
+        // Deliberately split so that sed does not touch this during build-time.
         if ($actVer !== $expVer && $expVer !== '%' . 'COOLWSD_VERSION_HASH' . '%') {
-			// Old/unexpected server version; restart.
+            // Old or unexpected server version; restart.
             error_log("Old server found, restarting. Expected hash $expVer but found $actVer.");
             stopCoolwsd();
 
-			// wait 10 seconds max
+            // Wait up to 10 seconds for shutdown.
             for ($i = 0; isCoolwsdRunning() && ($i < 10); $i++) {
                 sleep(1);
             }
 
-			// somebody else might have restarted it in the meantime
+            // Another process may have restarted it in the meantime.
             if (!isCoolwsdRunning()) {
                 startCoolwsd();
             }
@@ -301,7 +301,7 @@ function handleStatusRequest($local, $errno): void
 
 function rebuildMultipartBody(array $headers): string
 {
-    debug_log("Oh dear - PHP's rfc1867 handling doesn't give any php://input to work with");
+    debug_log("PHP's RFC 1867 upload handling leaves php://input empty for multipart requests.");
     debug_log("Reconstructing multipart body - Files: " . count($_FILES) . ", Form fields: " . count($_POST));
 
     $type = $headers['Content-Type'] ?? $headers['content-type'] ?? '';
@@ -323,7 +323,7 @@ function rebuildMultipartBody(array $headers): string
         $multiBody .= "Content-Disposition: form-data; name=\"file\"; filename=\"" . $file['name'] . "\"\r\n";
         $multiBody .= "Content-Type: " . $file['type'] . "\r\n\r\n";
         if ($file['tmp_name'] === '') {
-            errorExit("File " . $file['name'] . " is larger than maximum up-load file-size");
+            errorExit("File " . $file['name'] . " is larger than maximum upload file size");
         }
         $multiBody .= file_get_contents($file['tmp_name']) . "\r\n";
     }
@@ -404,14 +404,14 @@ debug_log('Proxy v1');
 // Let the webserver time us out in its own good time.
 set_time_limit(0);
 
-// Where the appimage is installed
+// Where the AppImage is installed.
 $appImage = __DIR__ . '/collabora/Collabora_Online.AppImage';
 
 $tmp_dir = ini_get('upload_tmp_dir') ? ini_get('upload_tmp_dir') : sys_get_temp_dir();
 $lockfile = "$tmp_dir/coolwsd.lock";
 $pidfile = "$tmp_dir/coolwsd.pid";
 
-// avoid unwanted escaping of req= parameter
+// Avoid unwanted escaping of the req= parameter.
 $request = $_SERVER['QUERY_STRING'];
 [$statusOnly, $request] = parseProxyMode($request);
 
@@ -435,20 +435,19 @@ if (startsWith($request, '/hosting/capabilities') && !isCoolwsdRunning()) {
     exit();
 }
 
-// If we can't get a socket open in 3 seconds when that is backed by
-// a dedicated thread, then we have a server missing in action.
+// If localhost:9983 does not accept connections within 3 seconds, treat the backend as unavailable.
 $local = @fsockopen("localhost", 9983, $errno, $errstr, 3);
 
-// Return the status and exit if it is a ?status request
+// Return the status response immediately if this is a ?status request.
 if ($statusOnly) {
     handleStatusRequest($local, $errno);
     exit();
 }
 
-// URL into this server of the proxy script.
+// Base URL for proxying back into this script.
 $proxyURL = getProxyScheme();
 
-// Start the appimage if necessary
+// Start coolwsd if necessary.
 if (!$local)
 {
     $err = checkCoolwsdSetup();
@@ -467,7 +466,7 @@ if (!$local)
             }
             usleep(50 * 1000); // 50ms.
         } else {
-            debug_log("connected?");
+            debug_log("Connected to the backend socket.");
             break;
         }
     }
@@ -477,7 +476,7 @@ if (!$local) {
     errorExit("Timed out opening local socket: $errno - $errstr");
 }
 
-// Fetch our headers for later
+// Read request headers so they can be forwarded to coolwsd.
 $headers = getallheaders();
 
 $proxyURL .= $_SERVER['HTTP_HOST'] . $_SERVER['SCRIPT_NAME'] . '?req=';
@@ -489,7 +488,7 @@ debug_log("Onward request is: '$realRequest'");
 $body = file_get_contents('php://input');
 debug_log("request content: '$body'");
 
-// Oh dear - PHP's rfc1867 handling doesn't give any php://input to work with in this case.
+// PHP's RFC 1867 upload handling leaves php://input empty for multipart requests.
 $multiBody = '';
 if ($body === '' && isMultipartRequest($headers)) {
     $body = rebuildMultipartBody($headers);
@@ -498,7 +497,7 @@ if ($body === '' && isMultipartRequest($headers)) {
 
 fwrite($local, $realRequest . "\r\n");
 
-// Send the headers on ...
+// Forward request headers to the backend.
 forwardRequestHeaders($local, $headers, $body, $multiBody);
 
 fwrite($local, "ProxyPrefix: " . $proxyURL . "\r\n");

--- a/proxy.php
+++ b/proxy.php
@@ -220,7 +220,7 @@ function parseProxyMode(string $queryString): array
     exitWithError("The param should be 'status' or 'req=...', but is: '" . $queryString . "'");
 }
 
-function getProxyScheme(): string
+function getRequestScheme(): string
 {
     if ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
         || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https')
@@ -441,7 +441,7 @@ if ($statusOnly) {
 }
 
 // Base URL for proxying back into this script.
-$proxyURL = getProxyScheme();
+$proxyURL = getRequestScheme();
 
 // Start coolwsd if necessary.
 if (!$local)

--- a/proxy.php
+++ b/proxy.php
@@ -28,7 +28,7 @@ function debug_log($msg)
     // error_log("richdocumentscode (proxy.php) debug, PID: " . getmypid() . ", Message: $msg");
 }
 
-function errorExit($msg)
+function exitWithError($msg)
 {
     http_response_code(400);
     print "<html><body>\n";
@@ -212,12 +212,12 @@ function parseProxyMode(string $queryString): array
     if (str_starts_with($queryString, 'req=')) {
         $request = substr($queryString, strlen('req='));
         if (substr($request, 0, 1) !== '/') {
-            errorExit("First ?req= param should be an absolute path: '" . $request . "'");
+            exitWithError("First ?req= param should be an absolute path: '" . $request . "'");
         }
         return ['statusOnly' => false, 'request' => $request];
     }
 
-    errorExit("The param should be 'status' or 'req=...', but is: '" . $queryString . "'");
+    exitWithError("The param should be 'status' or 'req=...', but is: '" . $queryString . "'");
 }
 
 function getProxyScheme(): string
@@ -319,7 +319,7 @@ function rebuildMultipartBody(array $headers): string
         $multiBody .= "Content-Disposition: form-data; name=\"file\"; filename=\"" . $file['name'] . "\"\r\n";
         $multiBody .= "Content-Type: " . $file['type'] . "\r\n\r\n";
         if ($file['tmp_name'] === '') {
-            errorExit("File " . $file['name'] . " is larger than maximum upload file size");
+            exitWithError("File " . $file['name'] . " is larger than maximum upload file size");
         }
         $multiBody .= file_get_contents($file['tmp_name']) . "\r\n";
     }
@@ -362,7 +362,7 @@ function streamCoolwsdResponse($local): void
         } elseif ($chunk === '') {
             debug_log("empty chunk last data");
             if ($parsingHeaders)
-                errorExit("No content in reply from coolwsd. Is SSL enabled in error ?");
+                exitWithError("No content in reply from coolwsd. Is SSL enabled in error ?");
             break;
         } elseif ($parsingHeaders) {
             $rest .= $chunk;
@@ -370,7 +370,7 @@ function streamCoolwsdResponse($local): void
             if (parseLastHeader($rest, $contentLength)) {
                 $parsingHeaders = false;
 
-                $extOut = fopen("php://output", "w") or errorExit("fundamental error opening PHP output");
+                $extOut = fopen("php://output", "w") or exitWithError("fundamental error opening PHP output");
                 fwrite($extOut, $rest);
                 $contentWritten += strlen($rest);
                 $rest = '';
@@ -414,7 +414,7 @@ $request = $_SERVER['QUERY_STRING'];
 debug_log("get URI " . $request);
 
 if ($request === '' && !$statusOnly)
-    errorExit("Missing, required req= parameter");
+    exitWithError("Missing, required req= parameter");
 
 if (str_starts_with($request, '/hosting/capabilities') && !isCoolwsdRunning()) {
     header('Content-type: application/json');
@@ -448,7 +448,7 @@ if (!$local)
 {
     $err = checkCoolwsdSetup();
     if (!empty($err))
-        errorExit($err);
+        exitWithError($err);
     else if (!isCoolwsdRunning())
         startCoolwsd();
 
@@ -469,7 +469,7 @@ if (!$local)
 }
 
 if (!$local) {
-    errorExit("Timed out opening local socket: $errno - $errstr");
+    exitWithError("Timed out opening local socket: $errno - $errstr");
 }
 
 // Read request headers so they can be forwarded to coolwsd.

--- a/proxy.php
+++ b/proxy.php
@@ -415,7 +415,7 @@ $pidFile = "$tmpDir/coolwsd.pid";
 
 // Avoid unwanted escaping of the req= parameter.
 $request = $_SERVER['QUERY_STRING'];
-[$statusOnly, $request] = parseRequestMode($request);
+['statusOnly' => $statusOnly, 'request' => $request] = parseRequestMode($request);
 
 debugLog("get URI " . $request);
 

--- a/proxy.php
+++ b/proxy.php
@@ -203,7 +203,7 @@ function isMultipartRequest($headers)
     return strpos(strtolower($contentType), 'multipart/form-data') !== false;
 }
 
-function parseProxyMode(string $queryString): array
+function parseRequestMode(string $queryString): array
 {
     if (str_starts_with($queryString, 'status')) {
         return ['statusOnly' => true, 'request' => ''];
@@ -409,7 +409,7 @@ $pidfile = "$tmp_dir/coolwsd.pid";
 
 // Avoid unwanted escaping of the req= parameter.
 $request = $_SERVER['QUERY_STRING'];
-[$statusOnly, $request] = parseProxyMode($request);
+[$statusOnly, $request] = parseRequestMode($request);
 
 debug_log("get URI " . $request);
 

--- a/proxy.php
+++ b/proxy.php
@@ -348,6 +348,53 @@ function forwardRequestHeaders($local, array $headers, string $body, string $mul
     }
 }
 
+function streamCoolwsdResponse($local): void
+{
+    $rest = '';
+    $contentLength = -1;
+    $contentWritten = 0;
+    $parsingHeaders = true;
+
+    do {
+        $chunk = fread($local, 65536);
+        if ($chunk === false) {
+            $error = error_get_last();
+            $errorMessage = $error ? implode(' ', $error) : 'No error';
+            echo "ERROR ! $errorMessage\n";
+            debug_log("error on chunk: $errorMessage");
+            break;
+        } elseif ($chunk === '') {
+            debug_log("empty chunk last data");
+            if ($parsingHeaders)
+                errorExit("No content in reply from coolwsd. Is SSL enabled in error ?");
+            break;
+        } elseif ($parsingHeaders) {
+            $rest .= $chunk;
+            debug_log("build headers to: $rest\n");
+            if (parseLastHeader($rest, $contentLength)) {
+                $parsingHeaders = false;
+
+                $extOut = fopen("php://output", "w") or errorExit("fundamental error opening PHP output");
+                fwrite($extOut, $rest);
+                $contentWritten += strlen($rest);
+                $rest = '';
+                debug_log("passed last headers");
+            }
+        } else {
+            fwrite($extOut, $chunk);
+            $contentWritten += strlen($chunk);
+            debug_log("proxy : " . strlen($chunk) . " bytes");
+        }
+
+        if ($contentLength != -1 && $contentWritten == $contentLength)
+        {
+            debug_log("reached ContentLength of $contentLength bytes");
+            break;
+        }
+
+    } while(true);
+}
+
 // ------------------------------------------------------------
 // Main script flow
 // ------------------------------------------------------------
@@ -460,48 +507,7 @@ fwrite($local, $body);
 
 debug_log("waiting for response");
 
-$rest = '';
-$contentLength = -1;
-$contentWritten = 0;
-$parsingHeaders = true;
-do {
-    $chunk = fread($local, 65536);
-    if($chunk === false) {
-        $error = error_get_last();
-        $errorMessage = $error ? implode(' ', $error) : 'No error';
-        echo "ERROR ! $errorMessage\n";
-        debug_log("error on chunk: $errorMessage");
-        break;
-    } elseif($chunk === '') {
-        debug_log("empty chunk last data");
-        if ($parsingHeaders)
-            errorExit("No content in reply from coolwsd. Is SSL enabled in error ?");
-        break;
-    } elseif ($parsingHeaders) {
-        $rest .= $chunk;
-        debug_log("build headers to: $rest\n");
-        if (parseLastHeader($rest, $contentLength)) {
-            $parsingHeaders = false;
-
-            $extOut = fopen("php://output", "w") or errorExit("fundamental error opening PHP output");
-            fwrite($extOut, $rest);
-            $contentWritten += strlen($rest);
-            $rest = '';
-            debug_log("passed last headers");
-        }
-    } else {
-        fwrite($extOut, $chunk);
-        $contentWritten += strlen($chunk);
-        debug_log("proxy : " . strlen($chunk) . " bytes");
-    }
-
-    if ($contentLength != -1 && $contentWritten == $contentLength)
-    {
-        debug_log("reached ContentLength of $contentLength bytes");
-        break;
-    }
-
-} while(true);
+streamCoolwsdResponse($local);
 
 debug_log("closing local socket");
 fclose($local);

--- a/proxy.php
+++ b/proxy.php
@@ -334,6 +334,20 @@ function rebuildMultipartBody(array $headers): string
     return $multiBody;
 }
 
+function forwardRequestHeaders($local, array $headers, string $body, string $multiBody): void
+{
+    foreach ($headers as $header => $value) {
+        debug_log("$header: $value\n");
+
+        if ($multiBody !== '' && $header === 'Content-Length') {
+            debug_log("Substitute Content-Length of " . $value . " with " . strlen($body));
+            $value = strlen($body);
+        }
+
+        fwrite($local, "$header: $value\r\n");
+    }
+}
+
 // ------------------------------------------------------------
 // Main script flow
 // ------------------------------------------------------------
@@ -436,17 +450,10 @@ if ($body === '' && isMultipartRequest($headers)) {
 }
 
 fwrite($local, $realRequest . "\r\n");
-// Send the headers on ...
-foreach ($headers as $header => $value) {
-    debug_log("$header: $value\n");
-    if ($multiBody !== '' && $header === 'Content-Length')
-    {
-        debug_log("Substitute Content-Length of " . $value . " with " . strlen($body));
-        $value = strlen($body);
-    }
 
-    fwrite($local, "$header: $value\r\n");
-}
+// Send the headers on ...
+forwardRequestHeaders($local, $headers, $body, $multiBody);
+
 fwrite($local, "ProxyPrefix: " . $proxyURL . "\r\n");
 fwrite($local, "\r\n");
 fwrite($local, $body);

--- a/proxy.php
+++ b/proxy.php
@@ -170,8 +170,8 @@ function checkCoolwsdSetup()
     return '';
 }
 
-// Parse upstream response headers and forward them with header().
-function forwardResponseHeaders(&$chunk, &$contentLength)
+// Parse upstream response headers, forward them with header(), and detect the end of the header block.
+function parseAndForwardHeaders(&$chunk, &$contentLength)
 {
     $headers = explode("\r\n", $chunk);
     debugLog("Headers: $chunk");
@@ -367,7 +367,7 @@ function streamCoolwsdResponse($local): void
         } elseif ($parsingHeaders) {
             $rest .= $chunk;
             debugLog("build headers to: $rest\n");
-            if (forwardResponseHeaders($rest, $contentLength)) {
+            if (parseAndForwardHeaders($rest, $contentLength)) {
                 $parsingHeaders = false;
 
                 $extOut = fopen("php://output", "w") or exitWithError("fundamental error opening PHP output");

--- a/proxy.php
+++ b/proxy.php
@@ -236,6 +236,69 @@ function getProxyScheme(): string
     return 'http://';
 }
 
+function handleStatusRequest($local, $errno): void
+{
+    header('Content-type: application/json');
+    header('Cache-Control: no-store');
+
+    if (!$local) {
+        $err = checkCoolwsdSetup();
+        if (!empty($err)) {
+            print '{"status":"error","error":"' . $err . '"}';
+            return;
+        }
+
+        if (!isCoolwsdRunning()) {
+            startCoolwsd();
+            print '{"status":"starting"}';
+            return;
+        }
+    } elseif ($errno === 111) {
+        print '{"status":"starting"}';
+        return;
+    }
+
+    $response = file_get_contents(
+        "http://localhost:9983/hosting/capabilities",
+        0,
+        stream_context_create(["http" => ["timeout" => 1]])
+    );
+
+    if ($response) {
+		// Version check.
+        $obj = json_decode($response);
+        $expVer = '%COOLWSD_VERSION_HASH%';
+        $actVer = substr($obj->{'productVersionHash'}, 0, strlen($expVer));
+
+		// deliberately split so that sed does not touch this during build-time
+        if ($actVer !== $expVer && $expVer !== '%' . 'COOLWSD_VERSION_HASH' . '%') {
+			// Old/unexpected server version; restart.
+            error_log("Old server found, restarting. Expected hash $expVer but found $actVer.");
+            stopCoolwsd();
+
+			// wait 10 seconds max
+            for ($i = 0; isCoolwsdRunning() && ($i < 10); $i++) {
+                sleep(1);
+            }
+
+			// somebody else might have restarted it in the meantime
+            if (!isCoolwsdRunning()) {
+                startCoolwsd();
+            }
+
+            print '{"status":"restarting"}';
+        } else {
+            print '{"status":"OK"}';
+        }
+    } else {
+        print '{"status":"starting"}';
+    }
+
+    if ($local) {
+        fclose($local);
+    }
+}
+
 // ------------------------------------------------------------
 // Main script flow
 // ------------------------------------------------------------
@@ -282,47 +345,7 @@ $local = @fsockopen("localhost", 9983, $errno, $errstr, 3);
 
 // Return the status and exit if it is a ?status request
 if ($statusOnly) {
-    header('Content-type: application/json');
-    header('Cache-Control: no-store');
-    if (!$local) {
-        $err = checkCoolwsdSetup();
-        if (!empty($err))
-            print '{"status":"error","error":"' . $err . '"}';
-        else if (!isCoolwsdRunning()) {
-            startCoolwsd();
-            print '{"status":"starting"}';
-        }
-    } else if ($errno === 111) {
-        print '{"status":"starting"}';
-    } else {
-        $response = file_get_contents("http://localhost:9983/hosting/capabilities", 0, stream_context_create(["http"=>["timeout"=>1]]));
-        if ($response) {
-            // Version check.
-            $obj = json_decode($response);
-            $expVer = '%COOLWSD_VERSION_HASH%';
-            $actVer = substr($obj->{'productVersionHash'}, 0, strlen($expVer));
-            if ($actVer !== $expVer && $expVer !== '%' . 'COOLWSD_VERSION_HASH' . '%') { // deliberately split so that sed does not touch this during build-time
-                // Old/unexpected server version; restart.
-                error_log("Old server found, restarting. Expected hash $expVer but found $actVer.");
-                stopCoolwsd();
-                // wait 10 seconds max
-                for ($i = 0; isCoolwsdRunning() && ($i < 10); $i++)
-                    sleep(1);
-
-                // somebody else might have restarted it in the meantime
-                if (!isCoolwsdRunning())
-                    startCoolwsd();
-
-                print '{"status":"restarting"}';
-            }
-            else
-                print '{"status":"OK"}';
-        }
-        else
-            print '{"status":"starting"}';
-        fclose($local);
-    }
-
+    handleStatusRequest($local, $errno);
     exit();
 }
 

--- a/proxy.php
+++ b/proxy.php
@@ -170,10 +170,6 @@ function checkCoolwsdSetup()
     return '';
 }
 
-function startsWith($string, $with) {
-    return (substr($string, 0, strlen($with)) === $with);
-}
-
 // Parse upstream response headers and forward them with header().
 function parseLastHeader(&$chunk, &$contentLength)
 {
@@ -190,7 +186,7 @@ function parseLastHeader(&$chunk, &$contentLength)
             $endOfHeaders = true;
             break;
         }
-        if (startsWith($h, 'Content-Length:'))
+        if (str_starts_with($h, 'Content-Length:'))
         {
             $contentLength = (int)trim(substr($h, strlen('Content-Length:')));
         }
@@ -209,11 +205,11 @@ function isMultipartRequest($headers)
 
 function parseProxyMode(string $queryString): array
 {
-    if (startsWith($queryString, 'status')) {
+    if (str_starts_with($queryString, 'status')) {
         return ['statusOnly' => true, 'request' => ''];
     }
 
-    if (startsWith($queryString, 'req=')) {
+    if (str_starts_with($queryString, 'req=')) {
         $request = substr($queryString, strlen('req='));
         if (substr($request, 0, 1) !== '/') {
             errorExit("First ?req= param should be an absolute path: '" . $request . "'");
@@ -420,7 +416,7 @@ debug_log("get URI " . $request);
 if ($request === '' && !$statusOnly)
     errorExit("Missing, required req= parameter");
 
-if (startsWith($request, '/hosting/capabilities') && !isCoolwsdRunning()) {
+if (str_starts_with($request, '/hosting/capabilities') && !isCoolwsdRunning()) {
     header('Content-type: application/json');
     header('Cache-Control: no-store');
 

--- a/proxy.php
+++ b/proxy.php
@@ -35,18 +35,6 @@ function errorExit($msg)
     exit();
 }
 
-debug_log('Proxy v1');
-
-// Let the webserver time us out in its own good time.
-set_time_limit(0);
-
-// Where the appimage is installed
-$appImage = __DIR__ . '/collabora/Collabora_Online.AppImage';
-
-$tmp_dir = ini_get('upload_tmp_dir') ? ini_get('upload_tmp_dir') : sys_get_temp_dir();
-$lockfile = "$tmp_dir/coolwsd.lock";
-$pidfile = "$tmp_dir/coolwsd.pid";
-
 function getCoolwsdPid()
 {
     global $pidfile;
@@ -209,6 +197,24 @@ function parseLastHeader(&$chunk, &$contentLength)
     return $endOfHeaders;
 }
 
+function isMultipartRequest($headers)
+{
+    $contentType = $headers['Content-Type'] ?? $headers['content-type'] ?? '';
+    return strpos(strtolower($contentType), 'multipart/form-data') !== false;
+}
+
+debug_log('Proxy v1');
+
+// Let the webserver time us out in its own good time.
+set_time_limit(0);
+
+// Where the appimage is installed
+$appImage = __DIR__ . '/collabora/Collabora_Online.AppImage';
+
+$tmp_dir = ini_get('upload_tmp_dir') ? ini_get('upload_tmp_dir') : sys_get_temp_dir();
+$lockfile = "$tmp_dir/coolwsd.lock";
+$pidfile = "$tmp_dir/coolwsd.pid";
+
 // avoid unwanted escaping of req= parameter
 $request = $_SERVER['QUERY_STRING'];
 // only asking for status?
@@ -295,6 +301,7 @@ if ($statusOnly) {
 
     exit();
 }
+
 // URL into this server of the proxy script.
 if ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
 	|| (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https' )
@@ -346,12 +353,6 @@ debug_log("Onward request is: '$realRequest'");
 $body = file_get_contents('php://input');
 debug_log("request content: '$body'");
 
-function isMultipartRequest($headers)
-{
-    $contentType = $headers['Content-Type'] ?? $headers['content-type'] ?? '';
-    return strpos(strtolower($contentType), 'multipart/form-data') !== false;
-}
-
 // Oh dear - PHP's rfc1867 handling doesn't give any php://input to work with in this case.
 $multiBody = '';
 if ($body === '' && isMultipartRequest($headers)) {
@@ -360,7 +361,7 @@ if ($body === '' && isMultipartRequest($headers)) {
 
     $type = isset($headers['Content-Type']) ? $headers['Content-Type'] : $headers['content-type'];
     $boundary = trim(explode('boundary=', $type)[1]);
-    foreach ($_REQUEST as $key=>$value) {
+    foreach ($_REQUEST as $key => $value) {
         if ($key === 'req') {
             continue;
         }

--- a/proxy.php
+++ b/proxy.php
@@ -22,13 +22,13 @@
 // Helper functions
 // ------------------------------------------------------------
 
-function debugLog($msg)
+function debugLog(string $msg): void
 {
     // Disabled for production; enable for debugging
     // error_log("richdocumentscode (proxy.php) debug, PID: " . getmypid() . ", Message: $msg");
 }
 
-function exitWithError($msg)
+function exitWithError(string $msg): void
 {
     http_response_code(400);
     print "<html><body>\n";
@@ -39,6 +39,9 @@ function exitWithError($msg)
     exit();
 }
 
+/**
+ * @return string|int Returns the process ID as a string, or 0 if the server is not running.
+ */
 function getCoolwsdPid()
 {
     global $pidfile;
@@ -55,6 +58,9 @@ function getCoolwsdPid()
     return 0;
 }
 
+/**
+ * @return bool|int Returns true if the process is running, false if not, or 0 if no PID file exists.
+ */
 function isCoolwsdRunning()
 {
     $pid = getCoolwsdPid();
@@ -64,7 +70,7 @@ function isCoolwsdRunning()
     return posix_kill($pid,0);
 }
 
-function startCoolwsd()
+function startCoolwsd(): void
 {
     global $appImage;
     global $pidfile;
@@ -124,7 +130,7 @@ function startCoolwsd()
         unlink("$lockfile");
 }
 
-function stopCoolwsd()
+function stopCoolwsd(): void
 {
     $pid = getCoolwsdPid();
     if (posix_kill($pid,0))
@@ -136,7 +142,7 @@ function stopCoolwsd()
 
 // Check whether the environment is suitable for running coolwsd.
 // Returns an error ID if a problem is found.
-function checkCoolwsdSetup()
+function checkCoolwsdSetup(): string
 {
     global $appImage;
 
@@ -171,7 +177,7 @@ function checkCoolwsdSetup()
 }
 
 // Parse upstream response headers, forward them with header(), and detect the end of the header block.
-function parseAndForwardHeaders(&$chunk, &$contentLength)
+function parseAndForwardHeaders(&$chunk, &$contentLength): bool
 {
     $headers = explode("\r\n", $chunk);
     debugLog("Headers: $chunk");
@@ -197,7 +203,7 @@ function parseAndForwardHeaders(&$chunk, &$contentLength)
     return $endOfHeaders;
 }
 
-function isMultipartRequest($headers)
+function isMultipartRequest(array $headers): bool
 {
     $contentType = $headers['Content-Type'] ?? $headers['content-type'] ?? '';
     return strpos(strtolower($contentType), 'multipart/form-data') !== false;

--- a/proxy.php
+++ b/proxy.php
@@ -299,6 +299,41 @@ function handleStatusRequest($local, $errno): void
     }
 }
 
+function rebuildMultipartBody(array $headers): string
+{
+    debug_log("Oh dear - PHP's rfc1867 handling doesn't give any php://input to work with");
+    debug_log("Reconstructing multipart body - Files: " . count($_FILES) . ", Form fields: " . count($_POST));
+
+    $type = $headers['Content-Type'] ?? $headers['content-type'] ?? '';
+    $boundary = trim(explode('boundary=', $type)[1]);
+
+    $multiBody = '';
+
+    foreach ($_REQUEST as $key => $value) {
+        if ($key === 'req') {
+            continue;
+        }
+        $multiBody .= "--" . $boundary . "\r\n";
+        $multiBody .= "Content-Disposition: form-data; name=\"$key\"\r\n\r\n";
+        $multiBody .= "$value\r\n";
+    }
+
+    foreach ($_FILES as $file) {
+        $multiBody .= "--" . $boundary . "\r\n";
+        $multiBody .= "Content-Disposition: form-data; name=\"file\"; filename=\"" . $file['name'] . "\"\r\n";
+        $multiBody .= "Content-Type: " . $file['type'] . "\r\n\r\n";
+        if ($file['tmp_name'] === '') {
+            errorExit("File " . $file['name'] . " is larger than maximum up-load file-size");
+        }
+        $multiBody .= file_get_contents($file['tmp_name']) . "\r\n";
+    }
+
+    $multiBody .= "--" . $boundary . "--\r\n";
+
+    debug_log("Reconstructed body: $multiBody");
+    return $multiBody;
+}
+
 // ------------------------------------------------------------
 // Main script flow
 // ------------------------------------------------------------
@@ -396,32 +431,8 @@ debug_log("request content: '$body'");
 // Oh dear - PHP's rfc1867 handling doesn't give any php://input to work with in this case.
 $multiBody = '';
 if ($body === '' && isMultipartRequest($headers)) {
-    debug_log("Oh dear - PHP's rfc1867 handling doesn't give any php://input to work with");
-	debug_log("Reconstructing multipart body - Files: " . count($_FILES) . ", Form fields: " . count($_POST));
-
-    $type = isset($headers['Content-Type']) ? $headers['Content-Type'] : $headers['content-type'];
-    $boundary = trim(explode('boundary=', $type)[1]);
-    foreach ($_REQUEST as $key => $value) {
-        if ($key === 'req') {
-            continue;
-        }
-        $multiBody .= "--" . $boundary . "\r\n";
-        $multiBody .= "Content-Disposition: form-data; name=\"$key\"\r\n\r\n";
-        $multiBody .= "$value\r\n";
-    }
-    foreach ($_FILES as $file) {
-        $multiBody .= "--" . $boundary . "\r\n";
-        $multiBody .= "Content-Disposition: form-data; name=\"file\"; filename=\"" . $file['name'] . "\"\r\n";
-        $multiBody .= "Content-Type: " . $file['type'] . "\r\n\r\n";
-        if ($file['tmp_name'] === '') {
-            errorExit("File " . $file['name'] . " is larger than maximum up-load file-size");
-        }
-        $multiBody .= file_get_contents($file['tmp_name']) . "\r\n";
-    }
-    $multiBody .= "--" . $boundary . "--\r\n";
-    $body = $multiBody;
-
-    debug_log("Reconstructed body: $body");
+    $body = rebuildMultipartBody($headers);
+    $multiBody = $body;
 }
 
 fwrite($local, $realRequest . "\r\n");

--- a/proxy.php
+++ b/proxy.php
@@ -44,12 +44,12 @@ function exitWithError(string $msg): void
  */
 function getCoolwsdPid()
 {
-    global $pidfile;
+    global $pidFile;
 
     clearstatcache();
-    if (file_exists($pidfile))
+    if (file_exists($pidFile))
     {
-        $pid = rtrim(file_get_contents($pidfile));
+        $pid = rtrim(file_get_contents($pidFile));
         debugLog("Coolwsd server running with pid: " . $pid);
         return $pid;
     }
@@ -73,8 +73,8 @@ function isCoolwsdRunning()
 function startCoolwsd(): void
 {
     global $appImage;
-    global $pidfile;
-    global $lockfile;
+    global $pidFile;
+    global $lockFile;
 
     // Remote font config URL (HTTPS only)
     $remoteFontConfig = "";
@@ -100,20 +100,20 @@ function startCoolwsd(): void
     // If lok_allow does not contain the Nextcloud host, it is not possible to insert images from Nextcloud.
     // We have to set it explicitly because storage.wopi.alias_groups[@mode] is 'first' in case of richdocumentscode.
     $lok_allow = "--o:net.lok_allow.host[14]=" . escapeshellarg($_SERVER['HTTP_HOST']);
-    $launchCmd = "bash -c \"( $appImage $remoteFontConfig $IPv4only $lok_allow --pidfile=$pidfile || $appImage --appimage-extract-and-run $remoteFontConfig $IPv4only $lok_allow --pidfile=$pidfile) >/dev/null & disown\"";
+    $launchCmd = "bash -c \"( $appImage $remoteFontConfig $IPv4only $lok_allow --pidfile=$pidFile || $appImage --appimage-extract-and-run $remoteFontConfig $IPv4only $lok_allow --pidfile=$pidFile) >/dev/null & disown\"";
 
     // Remove a stale lock file if one exists.
-    if (file_exists("$lockfile"))
-        if (time() - filectime("$lockfile") > 60 * 5)
-            unlink("$lockfile");
+    if (file_exists("$lockFile"))
+        if (time() - filectime("$lockFile") > 60 * 5)
+            unlink("$lockFile");
 
     // Prevent a second concurrent start.
-    $lock = @fopen("$lockfile", "x");
+    $lock = @fopen("$lockFile", "x");
     if ($lock)
     {
         // We are starting a new server, so we do not need a stale pidfile.
-        if (file_exists("$pidfile"))
-            unlink("$pidfile");
+        if (file_exists("$pidFile"))
+            unlink("$pidFile");
 
         debugLog("Launch the coolwsd server: $launchCmd");
         exec($launchCmd, $output, $return);
@@ -126,8 +126,8 @@ function startCoolwsd(): void
     while (!isCoolwsdRunning())
         sleep(1);
 
-    if (file_exists("$lockfile"))
-        unlink("$lockfile");
+    if (file_exists("$lockFile"))
+        unlink("$lockFile");
 }
 
 function stopCoolwsd(): void
@@ -238,12 +238,12 @@ function getRequestScheme(): string
     return 'http://';
 }
 
-function handleStatusRequest($local, $errno): void
+function handleStatusRequest($backendSocket, $errno): void
 {
     header('Content-type: application/json');
     header('Cache-Control: no-store');
 
-    if (!$local) {
+    if (!$backendSocket) {
         $err = checkCoolwsdSetup();
         if (!empty($err)) {
             print '{"status":"error","error":"' . $err . '"}';
@@ -296,8 +296,8 @@ function handleStatusRequest($local, $errno): void
         print '{"status":"starting"}';
     }
 
-    if ($local) {
-        fclose($local);
+    if ($backendSocket) {
+        fclose($backendSocket);
     }
 }
 
@@ -309,56 +309,56 @@ function rebuildMultipartBody(array $headers): string
     $type = $headers['Content-Type'] ?? $headers['content-type'] ?? '';
     $boundary = trim(explode('boundary=', $type)[1]);
 
-    $multiBody = '';
+    $multipartBody = '';
 
     foreach ($_REQUEST as $key => $value) {
         if ($key === 'req') {
             continue;
         }
-        $multiBody .= "--" . $boundary . "\r\n";
-        $multiBody .= "Content-Disposition: form-data; name=\"$key\"\r\n\r\n";
-        $multiBody .= "$value\r\n";
+        $multipartBody .= "--" . $boundary . "\r\n";
+        $multipartBody .= "Content-Disposition: form-data; name=\"$key\"\r\n\r\n";
+        $multipartBody .= "$value\r\n";
     }
 
     foreach ($_FILES as $file) {
-        $multiBody .= "--" . $boundary . "\r\n";
-        $multiBody .= "Content-Disposition: form-data; name=\"file\"; filename=\"" . $file['name'] . "\"\r\n";
-        $multiBody .= "Content-Type: " . $file['type'] . "\r\n\r\n";
+        $multipartBody .= "--" . $boundary . "\r\n";
+        $multipartBody .= "Content-Disposition: form-data; name=\"file\"; filename=\"" . $file['name'] . "\"\r\n";
+        $multipartBody .= "Content-Type: " . $file['type'] . "\r\n\r\n";
         if ($file['tmp_name'] === '') {
             exitWithError("File " . $file['name'] . " is larger than maximum upload file size");
         }
-        $multiBody .= file_get_contents($file['tmp_name']) . "\r\n";
+        $multipartBody .= file_get_contents($file['tmp_name']) . "\r\n";
     }
 
-    $multiBody .= "--" . $boundary . "--\r\n";
+    $multipartBody .= "--" . $boundary . "--\r\n";
 
-    debugLog("Reconstructed body: $multiBody");
-    return $multiBody;
+    debugLog("Reconstructed body: $multipartBody");
+    return $multipartBody;
 }
 
-function forwardRequestHeaders($local, array $headers, string $body, string $multiBody): void
+function forwardRequestHeaders($backendSocket, array $headers, string $body, string $multipartBody): void
 {
     foreach ($headers as $header => $value) {
         debugLog("$header: $value\n");
 
-        if ($multiBody !== '' && $header === 'Content-Length') {
+        if ($multipartBody !== '' && $header === 'Content-Length') {
             debugLog("Substitute Content-Length of " . $value . " with " . strlen($body));
             $value = strlen($body);
         }
 
-        fwrite($local, "$header: $value\r\n");
+        fwrite($backendSocket, "$header: $value\r\n");
     }
 }
 
-function streamCoolwsdResponse($local): void
+function streamCoolwsdResponse($backendSocket): void
 {
-    $rest = '';
+    $buffer = '';
     $contentLength = -1;
     $contentWritten = 0;
     $parsingHeaders = true;
 
     do {
-        $chunk = fread($local, 65536);
+        $chunk = fread($backendSocket, 65536);
         if ($chunk === false) {
             $error = error_get_last();
             $errorMessage = $error ? implode(' ', $error) : 'No error';
@@ -371,15 +371,15 @@ function streamCoolwsdResponse($local): void
                 exitWithError("No content in reply from coolwsd. Is SSL enabled in error ?");
             break;
         } elseif ($parsingHeaders) {
-            $rest .= $chunk;
-            debugLog("build headers to: $rest\n");
-            if (parseAndForwardHeaders($rest, $contentLength)) {
+            $buffer .= $chunk;
+            debugLog("build headers to: $buffer\n");
+            if (parseAndForwardHeaders($buffer, $contentLength)) {
                 $parsingHeaders = false;
 
                 $extOut = fopen("php://output", "w") or exitWithError("fundamental error opening PHP output");
-                fwrite($extOut, $rest);
-                $contentWritten += strlen($rest);
-                $rest = '';
+                fwrite($extOut, $buffer);
+                $contentWritten += strlen($buffer);
+                $buffer = '';
                 debugLog("passed last headers");
             }
         } else {
@@ -409,9 +409,9 @@ set_time_limit(0);
 // Where the AppImage is installed.
 $appImage = __DIR__ . '/collabora/Collabora_Online.AppImage';
 
-$tmp_dir = ini_get('upload_tmp_dir') ? ini_get('upload_tmp_dir') : sys_get_temp_dir();
-$lockfile = "$tmp_dir/coolwsd.lock";
-$pidfile = "$tmp_dir/coolwsd.pid";
+$tmpDir = ini_get('upload_tmp_dir') ? ini_get('upload_tmp_dir') : sys_get_temp_dir();
+$lockFile = "$tmpDir/coolwsd.lock";
+$pidFile = "$tmpDir/coolwsd.pid";
 
 // Avoid unwanted escaping of the req= parameter.
 $request = $_SERVER['QUERY_STRING'];
@@ -438,11 +438,11 @@ if (str_starts_with($request, '/hosting/capabilities') && !isCoolwsdRunning()) {
 }
 
 // If localhost:9983 does not accept connections within 3 seconds, treat the backend as unavailable.
-$local = @fsockopen("localhost", 9983, $errno, $errstr, 3);
+$backendSocket = @fsockopen("localhost", 9983, $errno, $errstr, 3);
 
 // Return the status response immediately if this is a ?status request.
 if ($statusOnly) {
-    handleStatusRequest($local, $errno);
+    handleStatusRequest($backendSocket, $errno);
     exit();
 }
 
@@ -450,7 +450,7 @@ if ($statusOnly) {
 $proxyURL = getRequestScheme();
 
 // Start coolwsd if necessary.
-if (!$local)
+if (!$backendSocket)
 {
     $err = checkCoolwsdSetup();
     if (!empty($err))
@@ -460,7 +460,7 @@ if (!$local)
 
     $logonce = true;
     while (true) {
-        $local = @fsockopen("localhost", 9983, $errno, $errstr, 15);
+        $backendSocket = @fsockopen("localhost", 9983, $errno, $errstr, 15);
         if ($errno === 111) {
             if($logonce) {
                debugLog("Can't yet connect to socket so sleep");
@@ -474,7 +474,7 @@ if (!$local)
     }
 }
 
-if (!$local) {
+if (!$backendSocket) {
     exitWithError("Timed out opening local socket: $errno - $errstr");
 }
 
@@ -491,26 +491,26 @@ $body = file_get_contents('php://input');
 debugLog("request content: '$body'");
 
 // PHP's RFC 1867 upload handling leaves php://input empty for multipart requests.
-$multiBody = '';
+$multipartBody = '';
 if ($body === '' && isMultipartRequest($headers)) {
     $body = rebuildMultipartBody($headers);
-    $multiBody = $body;
+    $multipartBody = $body;
 }
 
-fwrite($local, $realRequest . "\r\n");
+fwrite($backendSocket, $realRequest . "\r\n");
 
 // Forward request headers to the backend.
-forwardRequestHeaders($local, $headers, $body, $multiBody);
+forwardRequestHeaders($backendSocket, $headers, $body, $multipartBody);
 
-fwrite($local, "ProxyPrefix: " . $proxyURL . "\r\n");
-fwrite($local, "\r\n");
-fwrite($local, $body);
+fwrite($backendSocket, "ProxyPrefix: " . $proxyURL . "\r\n");
+fwrite($backendSocket, "\r\n");
+fwrite($backendSocket, $body);
 
 debugLog("waiting for response");
 
-streamCoolwsdResponse($local);
+streamCoolwsdResponse($backendSocket);
 
 debugLog("closing local socket");
-fclose($local);
+fclose($backendSocket);
 
 ?>

--- a/proxy.php
+++ b/proxy.php
@@ -224,6 +224,18 @@ function parseProxyMode(string $queryString): array
     errorExit("The param should be 'status' or 'req=...', but is: '" . $queryString . "'");
 }
 
+function getProxyScheme(): string
+{
+    if ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+        || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https')
+        || (isset($_SERVER['HTTP_X_FORWARDED_SSL']) && $_SERVER['HTTP_X_FORWARDED_SSL'] === 'on')
+	   ) {
+    	return 'https://';
+    }
+
+    return 'http://';
+}
+
 // ------------------------------------------------------------
 // Main script flow
 // ------------------------------------------------------------
@@ -315,14 +327,7 @@ if ($statusOnly) {
 }
 
 // URL into this server of the proxy script.
-if ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
-	|| (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https' )
-	|| (isset($_SERVER['HTTP_X_FORWARDED_SSL']) && $_SERVER['HTTP_X_FORWARDED_SSL'] === 'on')
-) {
-    $proxyURL = "https://";
-} else {
-    $proxyURL = "http://";
-}
+$proxyURL = getProxyScheme();
 
 // Start the appimage if necessary
 if (!$local)

--- a/proxy.php
+++ b/proxy.php
@@ -22,7 +22,7 @@
 // Helper functions
 // ------------------------------------------------------------
 
-function debug_log($msg)
+function debugLog($msg)
 {
     // Disabled for production; enable for debugging
     // error_log("richdocumentscode (proxy.php) debug, PID: " . getmypid() . ", Message: $msg");
@@ -47,11 +47,11 @@ function getCoolwsdPid()
     if (file_exists($pidfile))
     {
         $pid = rtrim(file_get_contents($pidfile));
-        debug_log("Coolwsd server running with pid: " . $pid);
+        debugLog("Coolwsd server running with pid: " . $pid);
         return $pid;
     }
 
-    debug_log("Coolwsd server is not running.");
+    debugLog("Coolwsd server is not running.");
     return 0;
 }
 
@@ -81,11 +81,11 @@ function startCoolwsd()
     // Check whether IPv6 has been disabled.
     $IPv4only = "";
     $launchCmd = "ip -6 addr";
-    debug_log("Testing disabled IPv6: $launchCmd");
+    debugLog("Testing disabled IPv6: $launchCmd");
     exec($launchCmd, $output, $return);
     if (implode("",$output)=="")
     {
-        debug_log("IPv6 disabled. Will launch coolwsd with IPv4-only option.");
+        debugLog("IPv6 disabled. Will launch coolwsd with IPv4-only option.");
         $IPv4only = "--o:net.proto=IPv4";
     }
 
@@ -109,10 +109,10 @@ function startCoolwsd()
         if (file_exists("$pidfile"))
             unlink("$pidfile");
 
-        debug_log("Launch the coolwsd server: $launchCmd");
+        debugLog("Launch the coolwsd server: $launchCmd");
         exec($launchCmd, $output, $return);
         if ($return)
-            debug_log("Failed to launch server at $appImage.");
+            debugLog("Failed to launch server at $appImage.");
 
         fclose($lock);
     }
@@ -129,7 +129,7 @@ function stopCoolwsd()
     $pid = getCoolwsdPid();
     if (posix_kill($pid,0))
     {
-        debug_log("Stopping the coolwsd server with pid: $pid");
+        debugLog("Stopping the coolwsd server with pid: $pid");
         posix_kill($pid, 15 /*SIGTERM*/);
     }
 }
@@ -174,12 +174,12 @@ function checkCoolwsdSetup()
 function forwardResponseHeaders(&$chunk, &$contentLength)
 {
     $headers = explode("\r\n", $chunk);
-    debug_log("Headers: $chunk");
+    debugLog("Headers: $chunk");
     $chop = 0;
     $endOfHeaders = false;
     foreach ($headers as $h)
     {
-        debug_log("send: $h");
+        debugLog("send: $h");
         $chop += strlen($h) + 2;
         if ($h === '')
         {
@@ -297,8 +297,8 @@ function handleStatusRequest($local, $errno): void
 
 function rebuildMultipartBody(array $headers): string
 {
-    debug_log("PHP's RFC 1867 upload handling leaves php://input empty for multipart requests.");
-    debug_log("Reconstructing multipart body - Files: " . count($_FILES) . ", Form fields: " . count($_POST));
+    debugLog("PHP's RFC 1867 upload handling leaves php://input empty for multipart requests.");
+    debugLog("Reconstructing multipart body - Files: " . count($_FILES) . ", Form fields: " . count($_POST));
 
     $type = $headers['Content-Type'] ?? $headers['content-type'] ?? '';
     $boundary = trim(explode('boundary=', $type)[1]);
@@ -326,17 +326,17 @@ function rebuildMultipartBody(array $headers): string
 
     $multiBody .= "--" . $boundary . "--\r\n";
 
-    debug_log("Reconstructed body: $multiBody");
+    debugLog("Reconstructed body: $multiBody");
     return $multiBody;
 }
 
 function forwardRequestHeaders($local, array $headers, string $body, string $multiBody): void
 {
     foreach ($headers as $header => $value) {
-        debug_log("$header: $value\n");
+        debugLog("$header: $value\n");
 
         if ($multiBody !== '' && $header === 'Content-Length') {
-            debug_log("Substitute Content-Length of " . $value . " with " . strlen($body));
+            debugLog("Substitute Content-Length of " . $value . " with " . strlen($body));
             $value = strlen($body);
         }
 
@@ -357,16 +357,16 @@ function streamCoolwsdResponse($local): void
             $error = error_get_last();
             $errorMessage = $error ? implode(' ', $error) : 'No error';
             echo "ERROR ! $errorMessage\n";
-            debug_log("error on chunk: $errorMessage");
+            debugLog("error on chunk: $errorMessage");
             break;
         } elseif ($chunk === '') {
-            debug_log("empty chunk last data");
+            debugLog("empty chunk last data");
             if ($parsingHeaders)
                 exitWithError("No content in reply from coolwsd. Is SSL enabled in error ?");
             break;
         } elseif ($parsingHeaders) {
             $rest .= $chunk;
-            debug_log("build headers to: $rest\n");
+            debugLog("build headers to: $rest\n");
             if (forwardResponseHeaders($rest, $contentLength)) {
                 $parsingHeaders = false;
 
@@ -374,17 +374,17 @@ function streamCoolwsdResponse($local): void
                 fwrite($extOut, $rest);
                 $contentWritten += strlen($rest);
                 $rest = '';
-                debug_log("passed last headers");
+                debugLog("passed last headers");
             }
         } else {
             fwrite($extOut, $chunk);
             $contentWritten += strlen($chunk);
-            debug_log("proxy : " . strlen($chunk) . " bytes");
+            debugLog("proxy : " . strlen($chunk) . " bytes");
         }
 
         if ($contentLength != -1 && $contentWritten == $contentLength)
         {
-            debug_log("reached ContentLength of $contentLength bytes");
+            debugLog("reached ContentLength of $contentLength bytes");
             break;
         }
 
@@ -395,7 +395,7 @@ function streamCoolwsdResponse($local): void
 // Main script flow
 // ------------------------------------------------------------
 
-debug_log('Proxy v1');
+debugLog('Proxy v1');
 
 // Let the webserver time us out in its own good time.
 set_time_limit(0);
@@ -411,7 +411,7 @@ $pidfile = "$tmp_dir/coolwsd.pid";
 $request = $_SERVER['QUERY_STRING'];
 [$statusOnly, $request] = parseRequestMode($request);
 
-debug_log("get URI " . $request);
+debugLog("get URI " . $request);
 
 if ($request === '' && !$statusOnly)
     exitWithError("Missing, required req= parameter");
@@ -457,12 +457,12 @@ if (!$local)
         $local = @fsockopen("localhost", 9983, $errno, $errstr, 15);
         if ($errno === 111) {
             if($logonce) {
-               debug_log("Can't yet connect to socket so sleep");
+               debugLog("Can't yet connect to socket so sleep");
                $logonce = false;
             }
             usleep(50 * 1000); // 50ms.
         } else {
-            debug_log("Connected to the backend socket.");
+            debugLog("Connected to the backend socket.");
             break;
         }
     }
@@ -476,13 +476,13 @@ if (!$local) {
 $headers = getallheaders();
 
 $proxyURL .= $_SERVER['HTTP_HOST'] . $_SERVER['SCRIPT_NAME'] . '?req=';
-debug_log("ProxyPrefix: '$proxyURL'");
+debugLog("ProxyPrefix: '$proxyURL'");
 
 $realRequest = $_SERVER['REQUEST_METHOD'] . " " . $request . " " . $_SERVER['SERVER_PROTOCOL'];
-debug_log("Onward request is: '$realRequest'");
+debugLog("Onward request is: '$realRequest'");
 
 $body = file_get_contents('php://input');
-debug_log("request content: '$body'");
+debugLog("request content: '$body'");
 
 // PHP's RFC 1867 upload handling leaves php://input empty for multipart requests.
 $multiBody = '';
@@ -500,11 +500,11 @@ fwrite($local, "ProxyPrefix: " . $proxyURL . "\r\n");
 fwrite($local, "\r\n");
 fwrite($local, $body);
 
-debug_log("waiting for response");
+debugLog("waiting for response");
 
 streamCoolwsdResponse($local);
 
-debug_log("closing local socket");
+debugLog("closing local socket");
 fclose($local);
 
 ?>

--- a/proxy.php
+++ b/proxy.php
@@ -171,7 +171,7 @@ function checkCoolwsdSetup()
 }
 
 // Parse upstream response headers and forward them with header().
-function parseLastHeader(&$chunk, &$contentLength)
+function forwardResponseHeaders(&$chunk, &$contentLength)
 {
     $headers = explode("\r\n", $chunk);
     debug_log("Headers: $chunk");
@@ -367,7 +367,7 @@ function streamCoolwsdResponse($local): void
         } elseif ($parsingHeaders) {
             $rest .= $chunk;
             debug_log("build headers to: $rest\n");
-            if (parseLastHeader($rest, $contentLength)) {
+            if (forwardResponseHeaders($rest, $contentLength)) {
                 $parsingHeaders = false;
 
                 $extOut = fopen("php://output", "w") or exitWithError("fundamental error opening PHP output");


### PR DESCRIPTION
## Summary

This branch is a refactor/cleanup of `proxy.php` with no intended functional change. It improves readability and maintainability by reorganizing the script into focused helper functions, consolidating the main flow, and clarifying comments and names.

* Extracts status handling, request parsing, multipart reconstruction, header forwarding, and response streaming into dedicated helpers.
* Replaces the custom `startsWith()` helper with native `str_starts_with()`.
* Renames key variables and functions for consistency and readability.
* Clarifies comments and debug messages without intentionally changing proxy behavior.
* Adds type hints where practical.

## Notes for reviewers

This is intended to be a structural refactor for readability and maintainability, so review is easiest by comparing control-flow equivalence between the extracted helpers and the prior inline logic. Each extraction is also in its own commit to further ease reviewability.

Tested locally with Nextcloud v33.