### PR TITLE
Fix fatal error on admin settings page: OC\Server magic getters removed

### DIFF
--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -17,7 +17,9 @@
 
 namespace OCA\RichDocumentsCODE\Settings;
 
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IURLGenerator;
 use OCP\Settings\ISettings;
 
 class Admin implements ISettings
@@ -33,7 +35,7 @@ class Admin implements ISettings
         $absoluteUrlAppInstall = '/';
         $appArch = 'x86_64';
 
-        $urlGenerator = \OC::$server->getURLGenerator();
+        $urlGenerator = \OC::$server->get(IURLGenerator::class);
         $absoluteUrl = $urlGenerator->getAbsoluteURL('/index.php/settings/apps/app-bundles/richdocuments');
         $absoluteUrlAdmin = $urlGenerator->getAbsoluteURL('/index.php/settings/admin/richdocuments');
         $absoluteUrlAppInstall = $urlGenerator->getAbsoluteURL('/index.php/settings/apps/app-bundles/richdocumentscode');
@@ -42,7 +44,7 @@ class Admin implements ISettings
             $appArch = 'aarch64';
         }
 
-        if (\OC::$server->getAppManager()->isEnabledForUser('richdocuments')) {
+        if (\OC::$server->get(IAppManager::class)->isEnabledForUser('richdocuments')) {
             $isEnabled = 'yes';
         }
 


### PR DESCRIPTION
## Problem

On Nextcloud core versions where the legacy magic getters have been removed from `OC\Server` (confirmed on Nextcloud 34.0.1), loading the admin settings page at `/settings/admin/richdocumentscode` throws a fatal error:

```
Call to undefined method OC\Server::getURLGenerator()
  in apps/richdocumentscode/lib/Settings/Admin.php:36
```

`Admin::getForm()` also calls `\OC::$server->getAppManager()` (line 45), which is affected the same way and would fail right after the first call is fixed.

`info.xml` declares `max-version="35"`, so the app is expected to work on this core version, but these two direct magic-getter calls were never migrated to the DI container's `get()` method like the rest of the app already does elsewhere.

## Fix

Replace both calls with `\OC::$server->get(SomeInterface::class)`, which is the supported way to fetch services from the container and remains stable across core versions (confirmed present via `SimpleContainer::get()`).

## Testing

Verified on a Nextcloud 34.0.1 instance: the admin settings page now renders without error after this change.